### PR TITLE
style: use env and gha if over bash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,13 +93,20 @@ jobs:
           expected: "custom_image_name"
           actual: ${{ needs.test-build-ok-with-custom-image-name.outputs.image_artifact }}
 
+  test-push-gcr-ok:
+    needs: test-build-ok-with-artifact
+    uses: ./.github/workflows/push.yml
+    with:
+      environment: dev
+      dockerfile: "fixture/Dockerfile.artifact"
+
   test-push-gcr-ok-with-tag:
     needs: test-build-ok-with-artifact
     uses: ./.github/workflows/push.yml
     with:
       environment: dev
-      dockerfile_name: "fixture/Dockerfile.artifact"
-      docker_tag: "ci-test-tag"
+      dockerfile: "fixture/Dockerfile.artifact"
+      image_tag: "ci-test-tag"
 
   test-tag-gcr-outputs-ok:
     runs-on: ubuntu-latest
@@ -108,16 +115,16 @@ jobs:
       - uses: nick-fields/assert-action@v2
         with:
           expected: "ci-test-tag"
-          actual: ${{ needs.test-push-gcr-ok-with-tag.outputs.docker_tag }}
+          actual: ${{ needs.test-push-gcr-ok-with-tag.outputs.image_tag }}
 
   test-push-acr-ok-with-tag:
     needs: test-build-ok-with-artifact
     uses: ./.github/workflows/push.yml
     with:
       environment: az-dev
-      repository_type: ACR
-      dockerfile_name: "fixture/Dockerfile.artifact"
-      docker_tag: "ci-test-tag"
+      cloud_provider: Azure
+      dockerfile: "fixture/Dockerfile.artifact"
+      image_tag: "ci-test-tag"
 
   test-tag-acr-outputs-ok:
     runs-on: ubuntu-latest
@@ -126,4 +133,4 @@ jobs:
       - uses: nick-fields/assert-action@v2
         with:
           expected: "ci-test-tag"
-          actual: ${{ needs.test-push-acr-ok-with-tag.outputs.docker_tag }}
+          actual: ${{ needs.test-push-acr-ok-with-tag.outputs.image_tag }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -71,24 +71,24 @@ jobs:
           exit 1
       - id: set-image-artifact-name
         shell: bash
-        if: env.GHA_DOCKER_PUSH_IMAGE_NAME == "repo_name"
+        if: env.GHA_DOCKER_PUSH_IMAGE_NAME == 'repo_name'
         run: |
           echo "GHA_DOCKER_PUSH_IMAGE_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
       - id: set-image-tag
         shell: bash
-        if: env.GHA_DOCKER_PUSH_IMAGE_TAG  == "image_tag"
+        if: env.GHA_DOCKER_PUSH_IMAGE_TAG  == 'image_tag'
         run: |
           SHA=${{ github.sha }}
           SHORT_SHA=${SHA:0:7}
           echo "GHA_DOCKER_PUSH_IMAGE_TAG=${{ env.GHA_DOCKER_PUSH_BRANCH_NAME }}.${{ env.GHA_DOCKER_PUSH_DATE }}-SHA$SHORT_SHA" >> $GITHUB_ENV
       - id: set-registry-azure
         shell: bash
-        if: env.GHA_DOCKER_PUSH_CLOUD_PROVIDER  == "Azure"
+        if: env.GHA_DOCKER_PUSH_CLOUD_PROVIDER  == 'Azure'
         run: |
           echo "GHA_DOCKER_PUSH_DOCKER_REGISTRY=acrentur001.azurecr.io" >> $GITHUB_ENV
       - id: set-registry-gcp
         shell: bash
-        if: env.GHA_DOCKER_PUSH_CLOUD_PROVIDER  == "GCP"
+        if: env.GHA_DOCKER_PUSH_CLOUD_PROVIDER  == 'GCP'
         run: |
           echo "GHA_DOCKER_PUSH_DOCKER_REGISTRY=eu.gcr.io/entur-system-1287" >> $GITHUB_ENV
       - id: set-image
@@ -99,27 +99,27 @@ jobs:
       - uses: docker/setup-buildx-action@v3.2.0
       - id: login-gcp
         uses: google-github-actions/auth@v2.1.2
-        if: inputs.cloud_provider == "GCP"
+        if: inputs.cloud_provider == 'GCP'
         with:
           workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.SERVICE_ACCOUNT }}
           token_format: "access_token"
       - id: login-gcr
         uses: docker/login-action@v3.1.0
-        if: inputs.cloud_provider == "GCP"
+        if: inputs.cloud_provider == 'GCP'
         with:
           registry: eu.gcr.io
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
       - id: login-azure
         uses: Azure/login@v2
-        if: inputs.cloud_provider == "Azure"
+        if: inputs.cloud_provider == 'Azure'
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       - id: login-acr
-        if: inputs.cloud_provider == "Azure"
+        if: inputs.cloud_provider == 'Azure'
         shell: bash
         run: |
           az acr login --name acrentur001

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -65,7 +65,7 @@ jobs:
           echo "GHA_DOCKER_PUSH_BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
       - id: verify-cloud-provider
         shell: bash
-        if: env.GHA_DOCKER_PUSH_CLOUD_PROVIDER != "GCR" && env.GHA_DOCKER_PUSH_CLOUD_PROVIDER != "Azure"
+        if: env.GHA_DOCKER_PUSH_CLOUD_PROVIDER != 'GCR' && env.GHA_DOCKER_PUSH_CLOUD_PROVIDER != 'Azure'
         run: |
           echo "cloud_provider can only be GCR or Azure"
           exit 1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -65,9 +65,9 @@ jobs:
           echo "GHA_DOCKER_PUSH_BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
       - id: verify-cloud-provider
         shell: bash
-        if: env.GHA_DOCKER_PUSH_CLOUD_PROVIDER != 'GCR' && env.GHA_DOCKER_PUSH_CLOUD_PROVIDER != 'Azure'
+        if: env.GHA_DOCKER_PUSH_CLOUD_PROVIDER != 'GCP' && env.GHA_DOCKER_PUSH_CLOUD_PROVIDER != 'Azure'
         run: |
-          echo "cloud_provider can only be GCR or Azure"
+          echo "cloud_provider can only be GCP or Azure"
           exit 1
       - id: set-image-artifact-name
         shell: bash

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,7 +3,7 @@ name: Entur/Docker/Push
 on:
   workflow_call:
     inputs:
-      image_artifact_name:
+      image_name:
         description: "GitHub artifact with Docker image"
         type: string
         default: "repo_name"
@@ -11,23 +11,23 @@ on:
         type: string
         description: "GitHub environment to use"
         default: "prd"
-      dockerfile_name:
+      dockerfile:
         description: "Dockerfile to use for build"
         type: string
         default: "Dockerfile"
-      docker_tag:
+      image_tag:
         description: "Docker tag"
         type: string
-        default: "docker_tag"
-      repository_type:
-        description: "Which repository to use. GCR/ACR"
+        default: "image_tag"
+      cloud_provider:
+        description: "Which repository to use. GCP/Azure"
         type: string
-        default: "GCR"
+        default: "GCP"
     outputs:
       image_name:
         value: ${{ jobs.push.outputs.image_name }}
-      docker_tag:
-        value: ${{ jobs.push.outputs.docker_tag }}
+      image_tag:
+        value: ${{ jobs.push.outputs.image_tag }}
 
 jobs:
   push:
@@ -38,105 +38,103 @@ jobs:
       id-token: write
     outputs:
       image_name: ${{ steps.push.outputs.metadata }}
-      docker_tag: ${{ env.GHA_DOCKER_PUSH_DOCKER_TAG }}
+      image_tag: ${{ env.GHA_DOCKER_PUSH_IMAGE_TAG }}
 
     timeout-minutes: 10
     steps:
       - id: set-env
         shell: bash
         run: |
-          echo "GHA_DOCKER_PUSH_IMAGE_ARTIFACT_NAME=${{ inputs.image_artifact_name }}" >> $GITHUB_ENV
-          echo "GHA_DOCKER_PUSH_GCR_PROJECT_ID=entur-system-1287" >> $GITHUB_ENV
-          echo "GHA_DOCKER_PUSH_DOCKERFILE_NAME=${{ inputs.dockerfile_name }}" >> $GITHUB_ENV
-          echo "GHA_DOCKER_PUSH_DOCKER_TAG=${{ inputs.docker_tag }}" >> $GITHUB_ENV
-      - id: set-image-name
-        shell: bash
-        run: |
-          if [[ "${{ env.GHA_DOCKER_PUSH_IMAGE_ARTIFACT_NAME }}" = "repo_name" ]]; then
-            echo "GHA_DOCKER_PUSH_IMAGE_ARTIFACT_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
-          fi
-      - id: set-shorten-branch-name-env
-        shell: bash
-        # This shortens a branch name (max 63 chars) and removes illegal characters for tags/labels in Helm / GCP.
-        # It will:
-        # Shorten to max length
-        # Removes any "-" if last
-        # Convert to lowercase and removes Norwegian characters
-        # Removes "/" slashes, e.g. feature/ETU... to feature-ETU... because illegal in labels in Helm / GCP
-        # Removes dots, e.g. feature.ETU... to feature-ETU... because it fails matching in Deploy system
-        # Removes exclamation marks, e.g. feature!ETU... to feature-ETU... because it fails matching in Deploy system
-        run: |
+          echo "GHA_DOCKER_PUSH_IMAGE_NAME=${{ inputs.image_name }}" >> $GITHUB_ENV
+          echo "GHA_DOCKER_PUSH_DOCKERFILE=${{ inputs.dockerfile }}" >> $GITHUB_ENV
+          echo "GHA_DOCKER_PUSH_IMAGE_TAG=${{ inputs.image_tag }}" >> $GITHUB_ENV
+          echo "GHA_DOCKER_PUSH_DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+          echo "GHA_DOCKER_PUSH_CLOUD_PROVIDER=${{ inputs.cloud_provider }}" >> $GITHUB_ENV
+          # Convert ref name to a valid git & docker tag name
           if [[ "${{ github.event_name }}" = "pull_request" ]]; then
             BRANCH_NAME=${{ github.head_ref }}
           else
             BRANCH_NAME=${{ github.ref_name }}
           fi
-          SHORT_BRANCH_NAME=${BRANCH_NAME:0:55}
-          SHORT_BRANCH_NAME=$(echo "$SHORT_BRANCH_NAME" | sed s'/[-]$//')
-          SHORT_BRANCH_NAME=$(echo "$SHORT_BRANCH_NAME" | tr '[:upper:]' '[:lower:]' | tr -d '[ÆØÅæøå]')
-          SHORT_BRANCH_NAME=${SHORT_BRANCH_NAME//\//-}
-          SHORT_BRANCH_NAME=${SHORT_BRANCH_NAME//./-}
-          SHORT_BRANCH_NAME=${SHORT_BRANCH_NAME//!/-}
-          echo "GHA_DOCKER_PUSH_BRANCH_TAG=$SHORT_BRANCH_NAME" >> $GITHUB_ENV
-      - id: set-date-env
+          BRANCH_NAME=${BRANCH_NAME:0:43} # truncate to max_len - len(.YYYYMMDD-SHA1234567)
+          BRANCH_NAME=$(echo "$BRANCH_NAME" | sed s'/[-]$//') # remove trailing -
+          BRANCH_NAME=$(echo "$BRANCH_NAME" | tr '[:upper:]' '[:lower:]' | tr -d '[ÆØÅæøå]') # to ASCII lower case
+          BRANCH_NAME=${BRANCH_NAME//\//-} # replace / with -
+          BRANCH_NAME=${BRANCH_NAME//./-}  # replace . with -
+          BRANCH_NAME=${BRANCH_NAME//!/-}  # replace ! with -
+          echo "GHA_DOCKER_PUSH_BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+      - id: verify-cloud-provider
         shell: bash
-        run: echo "GHA_DOCKER_PUSH_DATE=$(date +'%Y.%m.%d')" >> $GITHUB_ENV
-      - id: set-docker-tag-from-input-env
+        if: env.GHA_DOCKER_PUSH_CLOUD_PROVIDER != "GCR" && env.GHA_DOCKER_PUSH_CLOUD_PROVIDER != "Azure"
+        run: |
+          echo "cloud_provider can only be GCR or Azure"
+          exit 1
+      - id: set-image-artifact-name
+        shell: bash
+        if: env.GHA_DOCKER_PUSH_IMAGE_NAME == "repo_name"
+        run: |
+          echo "GHA_DOCKER_PUSH_IMAGE_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
+      - id: set-image-tag
+        shell: bash
+        if: env.GHA_DOCKER_PUSH_IMAGE_TAG  == "image_tag"
+        run: |
+          SHA=${{ github.sha }}
+          SHORT_SHA=${SHA:0:7}
+          echo "GHA_DOCKER_PUSH_IMAGE_TAG=${{ env.GHA_DOCKER_PUSH_BRANCH_NAME }}.${{ env.GHA_DOCKER_PUSH_DATE }}-SHA$SHORT_SHA" >> $GITHUB_ENV
+      - id: set-registry-azure
+        shell: bash
+        if: env.GHA_DOCKER_PUSH_CLOUD_PROVIDER  == "Azure"
+        run: |
+          echo "GHA_DOCKER_PUSH_DOCKER_REGISTRY=acrentur001.azurecr.io" >> $GITHUB_ENV
+      - id: set-registry-gcp
+        shell: bash
+        if: env.GHA_DOCKER_PUSH_CLOUD_PROVIDER  == "GCP"
+        run: |
+          echo "GHA_DOCKER_PUSH_DOCKER_REGISTRY=eu.gcr.io/entur-system-1287" >> $GITHUB_ENV
+      - id: set-image
         shell: bash
         run: |
-          if [[ "${{ env.GHA_DOCKER_PUSH_DOCKER_TAG }}" = "docker_tag" ]]; then
-            SHA=${{ github.sha }}
-            SHORT_SHA=${SHA:0:7}
-            echo "GHA_DOCKER_PUSH_DOCKER_TAG=${{ env.GHA_DOCKER_PUSH_BRANCH_TAG }}.${{ env.GHA_DOCKER_PUSH_DATE }}-SHA$SHORT_SHA" >> $GITHUB_ENV
-          fi
-      - id: set-repository-env
-        shell: bash
-        run: |
-          if [[ "${{ inputs.repository_type }}" = "GCR" ]]; then
-            echo "GHA_DOCKER_PUSH_META_IMAGES=eu.gcr.io/${{ env.GHA_DOCKER_PUSH_GCR_PROJECT_ID }}/${{ env.GHA_DOCKER_PUSH_IMAGE_ARTIFACT_NAME }}" >> $GITHUB_ENV
-          elif [[ "${{ inputs.repository_type }}" = "ACR" ]]; then
-            echo "GHA_DOCKER_PUSH_META_IMAGES=acrentur001.azurecr.io/${{ env.GHA_DOCKER_PUSH_IMAGE_ARTIFACT_NAME }}" >> $GITHUB_ENV
-          fi
+          echo "GHA_DOCKER_PUSH_IMAGE=${{ env.GHA_DOCKER_PUSH_DOCKER_REGISTRY}}/${{ env.GHA_DOCKER_PUSH_IMAGE_NAME }}" >> $GITHUB_ENV
       - uses: actions/checkout@v4.1.2
       - uses: docker/setup-buildx-action@v3.2.0
-      - id: auth
+      - id: login-gcp
         uses: google-github-actions/auth@v2.1.2
-        if: ${{ inputs.repository_type == 'GCR' }}
+        if: inputs.cloud_provider == "GCP"
         with:
           workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.SERVICE_ACCOUNT }}
-          token_format: 'access_token'
+          token_format: "access_token"
       - id: login-gcr
         uses: docker/login-action@v3.1.0
-        if: ${{ inputs.repository_type == 'GCR' }}
+        if: inputs.cloud_provider == "GCP"
         with:
           registry: eu.gcr.io
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
       - id: login-azure
         uses: Azure/login@v2
-        if: ${{ inputs.repository_type == 'ACR' }}
+        if: inputs.cloud_provider == "Azure"
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       - id: login-acr
-        if: ${{ inputs.repository_type == 'ACR' }}
+        if: inputs.cloud_provider == "Azure"
         shell: bash
         run: |
           az acr login --name acrentur001
       - id: download-image-artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.GHA_DOCKER_PUSH_IMAGE_ARTIFACT_NAME }}
+          name: ${{ env.GHA_DOCKER_PUSH_IMAGE_NAME }}
           path: /tmp
       - id: load-image
         run: |
-          docker load --input /tmp/${{ env.GHA_DOCKER_PUSH_IMAGE_ARTIFACT_NAME }}.tar
+          docker load --input /tmp/${{ env.GHA_DOCKER_PUSH_IMAGE_NAME }}.tar
       - id: meta
         uses: docker/metadata-action@v5.5.1
         with:
-          images: ${{ env.GHA_DOCKER_PUSH_META_IMAGES }}
+          images: ${{ env.GHA_DOCKER_PUSH_IMAGE }}
           tags: |
             type=schedule
             type=ref,event=branch
@@ -146,12 +144,12 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
-            type=raw,value=${{ env.GHA_DOCKER_PUSH_BRANCH_TAG }}
-            type=raw,value=${{ env.GHA_DOCKER_PUSH_DOCKER_TAG }}
+            type=raw,value=${{ env.GHA_DOCKER_PUSH_BRANCH_NAME }}
+            type=raw,value=${{ env.GHA_DOCKER_PUSH_IMAGE_TAG }}
       - id: push
         uses: docker/build-push-action@v5.3.0
         with:
-          file: ${{ env.GHA_DOCKER_PUSH_DOCKERFILE_NAME }}
+          file: ${{ env.GHA_DOCKER_PUSH_DOCKERFILE }}
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -110,7 +110,7 @@ jobs:
         with:
           registry: eu.gcr.io
           username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
+          password: ${{ steps.login-gcp.outputs.access_token }}
       - id: login-azure
         uses: Azure/login@v2
         if: inputs.cloud_provider == 'Azure'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           SHA=${{ github.sha }}
           SHORT_SHA=${SHA:0:7}
-          echo "GHA_DOCKER_PUSH_IMAGE_TAG=${{ env.GHA_DOCKER_PUSH_BRANCH_NAME }}.${{ env.GHA_DOCKER_PUSH_DATE }}-SHA$SHORT_SHA" >> $GITHUB_ENV
+          echo "GHA_DOCKER_PUSH_IMAGE_TAG=${{ env.GHA_DOCKER_PUSH_BRANCH_NAME }}.${{ env.GHA_DOCKER_PUSH_DATE }}-SHA${SHORT_SHA}" >> $GITHUB_ENV
       - id: set-registry-azure
         shell: bash
         if: env.GHA_DOCKER_PUSH_CLOUD_PROVIDER  == 'Azure'


### PR DESCRIPTION
# This is purely a cosmetic change

This PR enforces the `use env in steps` style.
Furthermore, I have extracted the bash if statements out to gha if, this way it is more clear that a skip happened in the logs.

I have taken a pass at renaming in a way that makes sense to me now, and hopefully still makes sense after we slightly change our underlying technologies (for instance from GCR to GAR).

Let's take the opportunity to have a discussion and come to an agreement.

## It kind of does look clean though?
![image](https://github.com/entur/gha-docker/assets/721090/47f68472-addf-40cf-972d-625eaae4933e)
