### PR TITLE
fix: tag on push

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -57,8 +57,9 @@ jobs:
     timeout-minutes: ${{ inputs.timeout_minutes }}
     environment: ${{ inputs.environment }}
     permissions:
-      contents: read
+      contents: write
       id-token: write
+      pull-requests: write
     outputs:
       meta: ${{ steps.push.outputs.metadata }}
       image_name: ${{ env.GHA_DOCKER_PUSH_IMAGE_NAME }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -145,9 +145,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           provenance: false
       - id: tag-version
-        needs: push
         env:
-          IMAGE_TAG: ${{ needs.push.outputs.image_name }}:${{ needs.push.outputs.image_tag }}
+          IMAGE_TAG: ${{ steps.push.outputs.image_name }}:${{ steps.push.outputs.image_tag }}
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -146,9 +146,9 @@ jobs:
           provenance: false
       - id: tag-version
         env:
-          IMAGE_TAG: ${{ steps.push.outputs.image_name }}.${{ steps.push.outputs.image_tag }}
+          GHA_DOCKER_PUSH_GIT_TAG: ${{ env.GHA_DOCKER_PUSH_IMAGE_NAME }}.${{ env.GHA_DOCKER_PUSH_IMAGE_TAG }}
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git tag -a "$IMAGE_TAG" -m "chore(tag): $IMAGE_TAG [ckip ci]"
-          git push origin "$IMAGE_TAG"
+          git tag -a "$GHA_DOCKER_PUSH_GIT_TAG" -m "chore(tag): $GHA_DOCKER_PUSH_GIT_TAG [ckip ci]"
+          git push origin "$GHA_DOCKER_PUSH_GIT_TAG"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -144,3 +144,12 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           provenance: false
+      - id: tag-version
+        needs: push
+        env:
+          IMAGE_TAG: ${{ needs.push.outputs.image_name }}:${{ needs.push.outputs.image_tag }}
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git tag -a "$IMAGE_TAG" -m "chore(tag): $IMAGE_TAG [ckip ci]"
+          git push origin "$IMAGE_TAG"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -152,4 +152,4 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git tag -a "$GHA_DOCKER_PUSH_GIT_TAG" -m "chore(tag): $GHA_DOCKER_PUSH_GIT_TAG [ckip ci]"
-          git push origin "$GHA_DOCKER_PUSH_GIT_TAG"
+          git push origin "$GHA_DOCKER_PUSH_GIT_TAG" --force

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -146,7 +146,7 @@ jobs:
           provenance: false
       - id: tag-version
         env:
-          IMAGE_TAG: ${{ steps.push.outputs.image_name }}:${{ steps.push.outputs.image_tag }}
+          IMAGE_TAG: ${{ steps.push.outputs.image_name }}.${{ steps.push.outputs.image_tag }}
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com


### PR DESCRIPTION
Useful when handing over CD to external systems as they can use the image from docker trigger to do a git checkout