### PR TITLE
Navngir selve jobben i Entur/Docker/Lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   lint:
+    name: Docker Lint
     runs-on: ubuntu-24.04
     timeout-minutes: ${{ inputs.timeout_minutes }}
     permissions:


### PR DESCRIPTION
Navngir selve jobben i Entur/Docker/Lint workflowen sånn at navnet vises i Workflow grafen der denne er brukt.

P.t. ser det slik ut (Docker Lint er den øverste jobben, men det er ikke åpenbart):

<img width="283" alt="Screenshot 2024-08-30 at 14 12 35" src="https://github.com/user-attachments/assets/06117406-acf4-4968-b542-b76dc4fa2f9a">