### PR TITLE
feat: Adds input to docker-build to supply a Dockerfile GHA artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,13 @@ on:
         description: "Dockerfile to use for build"
         type: string
         default: "Dockerfile"
+      dockerfile_artifact_name:
+        description: "Name of Dockerfile GitHub artifact to add to build."
+        type: string
+      dockerfile_artifact_filename:
+        description: "Name of Dockerfile in artifact"
+        type: string
+        default: "Dockerfile"
       image_name:
         description: "Image name to use for the build"
         type: string
@@ -50,6 +57,8 @@ jobs:
     env:
       GHA_DOCKER_BUILD_CONTEXT: ${{ inputs.context }}
       GHA_DOCKER_BUILD_DOCKERFILE: ${{ inputs.dockerfile }}
+      GHA_DOCKER_BUILD_DOCKERFILE_ARTIFACT_NAME: ${{ inputs.dockerfile_artifact_name }}
+      GHA_DOCKER_BUILD_DOCKERFILE_ARTIFACT_FILENAME: ${{ inputs.dockerfile_artifact_filename }}
       GHA_DOCKER_BUILD_ARTIFACT_PATH: ${{ inputs.build_artifact_path }}
       GHA_DOCKER_BUILD_ARTIFACT_NAME: ${{ inputs.build_artifact_name }}
       GHA_DOCKER_BUILD_IMAGE_NAME: ${{ inputs.image_name }}
@@ -79,7 +88,7 @@ jobs:
 
       - if: env.GHA_DOCKER_BUILD_ARTIFACT_NAME != ''
         name: Download artifact ${{ env.GHA_DOCKER_BUILD_ARTIFACT_NAME }}
-        id: download-artifact
+        id: download-build-artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ env.GHA_DOCKER_BUILD_ARTIFACT_NAME }}
@@ -87,10 +96,28 @@ jobs:
 
       - if: env.GHA_DOCKER_BUILD_ARTIFACT_NAME != ''
         name: List artifacts in ${{ env.GHA_DOCKER_BUILD_ARTIFACT_PATH }}
-        id: list-artifacts
+        id: list-build-artifacts
         shell: bash
         run: ls -l ${{ env.GHA_DOCKER_BUILD_ARTIFACT_PATH }}
 
+      - if: env.GHA_DOCKER_BUILD_DOCKERFILE_ARTIFACT_NAME != ''
+        name: Download Dockerfile artifact
+        id: download-dockerfile-artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.GHA_DOCKER_BUILD_DOCKERFILE_ARTIFACT_NAME }}
+          path: /tmp/dockerfile-artifact/
+
+      - if: env.GHA_DOCKER_BUILD_DOCKERFILE_ARTIFACT_NAME != ''
+        name: Set Dockerfile path in env for build step
+        id: set-dockerfile-path
+        run: |
+          # If Dockerfile already exists in repo, use that for building. If Dockerfile artifact is given and a
+          # Dockerfile does not exist in repo, build directly from artifact instead.
+          if [ ! -f "${{ GHA_DOCKER_BUILD_DOCKERFILE }}" ]; then
+            echo "GHA_DOCKER_BUILD_DOCKERFILE=/tmp/dockerfile-artifact/${{ GHA_DOCKER_BUILD_DOCKERFILE_ARTIFACT_FILENAME }}" >> $GITHUB_ENV
+          fi
+            
       - name: Setup buildx
         id: setup-buildx
         uses: docker/setup-buildx-action@v3.6.1


### PR DESCRIPTION
Allows for sourcing a Dockerfile from outside of the target repository, be it from a generated file or another repo entirely. Only chosen as Dockerfile for building if none already exists in the repository.

This is in the spirit of opening for small ways to step outside of the Golden Path without abandoning it entirely.

May be used like so:

```
jobs:
  generate-dockerfile:
    - name: Generate Dockerfile
      run: |
        cat > Dockerfile <<EOF
        <awesome dockerfile>
        EOF

    - name: Upload Dockerfile artifact
      uses: actions/upload-artifact@v4
      with:
        name: my-dockerfile-artifact
        path: Dockerfile

  docker-build:
    - name: Docker Build
      uses: entur/gha-docker/.github/workflows/build.yml@v1
      with:
        dockerfile_artifact_name: my-dockerfile-artifact
        ...<more options>
```

```
jobs:
  fetch-dockerfile:
    - name: Fetch Dockerfile
      run: <download awesome Dockerfile from somewhere> > awesome.Dockerfile

    - name: Upload Dockerfile artifact
      uses: actions/upload-artifact@v4
      with:
        name: my-dockerfile-artifact
        path: awesome.Dockerfile

  docker-build:
    - name: Docker Build
      uses: entur/gha-docker/.github/workflows/build.yml@v1
      with:
        dockerfile_artifact_name: my-dockerfile-artifact
        dockerfile_artifact_filename: awesome.Dockerfile
        ...<more options>
```

NOTE: May require some testing 😄 

Future ideas that were considered but abandoned for this PR:
- Specifying an additional path to store the artifact, such that you could supply multiple Dockerfiles for use with [`INCLUDE+`](https://github.com/edrevo/dockerfile-plus), maybe.
- Supply an artifact with files to be included in the Docker context. Opens up for generating arbitrary build files without needing to have them checked into each app. We may want this in Team Salg for uploading heap dumps on OOM so may create a PR for this later.