### PR TITLE
Checkout default ref when checking out code in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,6 @@ jobs:
       GHA_DOCKER_BUILD_ARTIFACT_NAME: ${{ inputs.build_artifact_name }}
       GHA_DOCKER_BUILD_IMAGE_NAME: ${{ inputs.image_name }}
       GHA_DOCKER_PUSH_CLOUD_PROVIDER: ${{ inputs.cloud_provider }}
-      GHA_REF: ""
     steps:
       - name: Set variables
         id: set-vars
@@ -63,18 +62,11 @@ jobs:
           if [[ "${GHA_DOCKER_BUILD_IMAGE_NAME}" = "repo_name" ]]; then
             echo "GHA_DOCKER_BUILD_IMAGE_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
           fi
-          if [[ "${GITHUB_EVENT_NAME}" = "pull_request" ]]; then
-             GHA_REF=${GITHUB_HEAD_REF}
-          else
-             GHA_REF=${GITHUB_REF_NAME}
-          fi
-          echo "GHA_REF=${GHA_REF}" >> $GITHUB_ENV
 
       - name: Checkout code
         id: checkout-code
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.GHA_REF }}
           fetch-depth: 0
 
       - if: env.GHA_DOCKER_BUILD_ARTIFACT_NAME != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,23 +19,10 @@ jobs:
   assert-lint-fail-ok:
     runs-on: ubuntu-24.04
     env:
-      GHA_REF: ""
       HADOLINT_RESULTS: ""
     steps:
-      - name: Set variables
-        id: set-vars
-        shell: bash
-        run: |
-          if [[ "${GITHUB_EVENT_NAME}" = "pull_request" ]]; then
-             GHA_REF=${GITHUB_HEAD_REF}
-          else
-             GHA_REF=${GITHUB_REF_NAME}
-          fi
-          echo "GHA_REF=${GHA_REF}" >> $GITHUB_ENV
-
       - uses: actions/checkout@v4
         with:
-          ref: ${{ env.GHA_REF }}
           fetch-depth: 0
       - uses: hadolint/hadolint-action@v3.1.0
         id: hadolint
@@ -51,22 +38,9 @@ jobs:
   test-build-prepare-artifact:
     needs: test-lint-ok
     runs-on: ubuntu-24.04
-    env:
-      GHA_REF: ""
     steps:
-      - name: Set variables
-        id: set-vars
-        shell: bash
-        run: |
-          if [[ "${GITHUB_EVENT_NAME}" = "pull_request" ]]; then
-             GHA_REF=${GITHUB_HEAD_REF}
-          else
-             GHA_REF=${GITHUB_REF_NAME}
-          fi
-          echo "GHA_REF=${GHA_REF}" >> $GITHUB_ENV
       - uses: actions/checkout@v4
         with:
-          ref: ${{ env.GHA_REF }}
           fetch-depth: 0
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,21 +25,9 @@ jobs:
     env:
       GHA_DOCKER_LINT_DOCKERFILE: ${{ inputs.dockerfile }}
       GHA_DOCKER_LINT_IGNORE: ${{ inputs.ignore }}
-      GHA_REF: ""
     steps:
-      - name: Set variables
-        id: set-vars
-        shell: bash
-        run: |
-          if [[ "${GITHUB_EVENT_NAME}" = "pull_request" ]]; then
-             GHA_REF=${GITHUB_HEAD_REF}
-          else
-             GHA_REF=${GITHUB_REF_NAME}
-          fi
-          echo "GHA_REF=${GHA_REF}" >> $GITHUB_ENV
       - uses: actions/checkout@v4
         with:
-          ref: ${{ env.GHA_REF }}
           fetch-depth: 0
       - uses: hadolint/hadolint-action@v3.1.0
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -48,7 +48,6 @@ env:
   GHA_DOCKER_PUSH_BRANCH_NAME: ""
   GHA_DOCKER_PUSH_DOCKER_REGISTRY: ""
   GHA_DOCKER_PUSH_IMAGE: ""
-  GHA_REF: ""
 jobs:
   push:
     name: Docker Push
@@ -116,17 +115,10 @@ jobs:
         shell: bash
         run: |
           echo "GHA_DOCKER_PUSH_IMAGE=${GHA_DOCKER_PUSH_DOCKER_REGISTRY}/${GHA_DOCKER_PUSH_IMAGE_NAME}" >> $GITHUB_ENV
-          if [[ "${GITHUB_EVENT_NAME}" = "pull_request" ]]; then
-             GHA_REF=${GITHUB_HEAD_REF}
-          else
-             GHA_REF=${GITHUB_REF_NAME}
-          fi
-          echo "GHA_REF=${GHA_REF}" >> $GITHUB_ENV
 
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.GHA_REF }}
           fetch-depth: 0
 
       - name: Download docker image from the artifact storage


### PR DESCRIPTION
Would previously try to check out HEAD_REF on PR or REF_NAME on branch, thus trying to checkout a fork-branch that does not exist in main repo. actions/checkout should handle this just fine without overriding ref.

See current errors on #129:
<img width="412" alt="Screenshot 2024-10-03 at 11 29 34" src="https://github.com/user-attachments/assets/38ef5f9c-c500-446d-aaf1-25d01fe89031">
<img width="749" alt="Screenshot 2024-10-03 at 11 29 37" src="https://github.com/user-attachments/assets/80131aa8-caea-47f7-b034-89ec0980db1e">
