### PR TITLE
chore: force pushe git tag instead of delete in separate step

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -165,7 +165,5 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git tag -d "$GHA_DOCKER_PUSH_IMAGE_TAG" || true
-          git push origin :"$GHA_DOCKER_PUSH_IMAGE_TAG" || true
-          git tag -a "$GHA_DOCKER_PUSH_IMAGE_TAG" -m "chore(tag): $GHA_DOCKER_PUSH_IMAGE_TAG [skip ci]"
+          git tag --annotate "$GHA_DOCKER_PUSH_IMAGE_TAG" -m "chore(tag): $GHA_DOCKER_PUSH_IMAGE_TAG [skip ci]" --force
           git push origin "$GHA_DOCKER_PUSH_IMAGE_TAG" --force


### PR DESCRIPTION
Force pushes git tags instead of deleting them in a separate step. Avoids unnecessary error messages when trying to delete a tag that does not exist:
<img width="626" alt="Screenshot 2024-10-03 at 11 34 15" src="https://github.com/user-attachments/assets/00ef939d-d8a6-4281-939e-f1fa4bb56615">

Supersedes #132.