### PR TITLE
build(deps): bump hadolint/hadolint-action from 3.1.0 to 3.2.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: hadolint/hadolint-action@v3.1.0
+      - uses: hadolint/hadolint-action@v3.2.0
         with:
           dockerfile: ${{ env.GHA_DOCKER_LINT_DOCKERFILE }}
           ignore: ${{ env.GHA_DOCKER_LINT_IGNORE }}


### PR DESCRIPTION
Upgrades hadolint from 2.12.0 to 2.13.1: https://github.com/hadolint/hadolint/releases/tag/v2.13.1