### PR TITLE
chore: fix dependabot exclude-paths config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,11 @@ version: 2
 updates:
 - package-ecosystem: "github-actions"
   directories:
-  - /
+  - "/"
   exclude-paths:
-  - /.github/workflows/build.yml
-  - /.github/workflows/lint.yml
-  - /.github/workflows/push.yml
+  - ".github/workflows/build.yml"
+  - ".github/workflows/lint.yml"
+  - ".github/workflows/push.yml"
   groups:
     minor-and-patch:
       applies-to: version-updates
@@ -22,9 +22,9 @@ updates:
   open-pull-requests-limit: 2
 - package-ecosystem: "github-actions"
   directories:
-  - /.github/workflows/build.yml
-  - /.github/workflows/lint.yml
-  - /.github/workflows/push.yml
+  - "/.github/workflows/build.yml"
+  - "/.github/workflows/lint.yml"
+  - "/.github/workflows/push.yml"
   groups:
     minor-and-patch:
       applies-to: version-updates


### PR DESCRIPTION
Dependabot exclude-paths config can't have leading slash.