### PR TITLE
feat!: Bump actions/checkout to v7. For most workflows this is not br…

### DIFF
--- a/.github/actions/resolve-image/README.md
+++ b/.github/actions/resolve-image/README.md
@@ -23,7 +23,7 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,14 +93,14 @@ jobs:
 
       - name: Checkout code
         id: checkout-code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: env.GHA_GIT_REF == ''
         with:
           submodules: recursive
           
       - name: Checkout code with reference
         id: checkout-code-ref
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: env.GHA_GIT_REF != ''
         with:
           submodules: recursive

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     env:
       HADOLINT_RESULTS: ""
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         id: hadolint
         continue-on-error: true
@@ -59,7 +59,7 @@ jobs:
     needs: test-lint-ok
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build_artifact
@@ -80,7 +80,7 @@ jobs:
     needs: test-lint-ok
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build_artifact_additional

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
       GHA_DOCKER_LINT_DOCKERFILE: ${{ inputs.dockerfile }}
       GHA_DOCKER_LINT_IGNORE: ${{ inputs.ignore }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
       - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -151,14 +151,14 @@ jobs:
 
       - name: Checkout code
         id: checkout-code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: env.GHA_DOCKER_PUSH_GIT_REF== ''
         with:
           submodules: recursive
 
       - name: Checkout code with reference
         id: checkout-code-ref
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: env.GHA_DOCKER_PUSH_GIT_REF!= ''
         with:
           submodules: recursive


### PR DESCRIPTION
…eaking, however if you are using pull_request_target, you need to fix this first.





## 💣 Breaking changes (if applicable)

<!-- Describe what breaks and how to migrate -->
<!-- ⚠️ A breaking change needs a new major version:
     - the PR title must be `type!: ...`, or the description must contain a `BREAKING CHANGE: ...` footer
     - without it, release-please only cuts a patch/minor and consumers get the change silently on the current major version -->
<!-- Remove the section if not relevant -->
For most workflows this is not breaking, however if you are using pull_request_target, you need to fix this first.
See github.com/actions/checkout#whats-new for more information.

